### PR TITLE
WebSocketServer improvements:

### DIFF
--- a/examples/server.py
+++ b/examples/server.py
@@ -63,4 +63,7 @@ async def handler(websocket):
 
 
 if __name__ == '__main__':
-    trio.run(main, parse_args())
+    try:
+        trio.run(main, parse_args())
+    except KeyboardInterrupt:
+        print()


### PR DESCRIPTION
   * listen() supports nursery start() protocol so we can
     block on server being ready for connections

   * port is read back from the socket and exposed via property
     so we can let OS select port (via port=0)

   * remove listen() KeyboardInterrupt handling and suppression

Fixes #8 and #6.