### PR TITLE
Remove client class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.pytest_cache
 __pycache__
 dist
 examples/fake.*

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you want to help develop `trio-websocket`, clone [the
 repository](https://github.com/hyperiongray/trio-websocket) and run this command
 from the repository root:
 
-    pip install --editable .
+    pip install --editable .[dev]
 
 ## Sample client
 
@@ -39,7 +39,11 @@ example client sends a text message and then disconnects.
 
     trio.run(main)
 
-A more detailed example is in `examples/client.py`.
+A more detailed example is in `examples/client.py`. **Note:** if you want to run
+this example client with SSL, you'll need to install the `trustme` module from
+PyPI (installed automtically if you used the `[dev]` extras when installing
+`trio-websocket`) and then generate a self-signed certificate by running
+`example/generate-cert.py`.
 
 ## Sample server
 
@@ -64,7 +68,8 @@ to each incoming message with an identical outgoing message.
 
     trio.run(main)
 
-A longer example is in `examples/server.py`.
+A longer example is in `examples/server.py`. **See the note above about using
+SSL with the example client.**
 
 ## Integration Testing with Autobahn
 

--- a/README.md
+++ b/README.md
@@ -18,24 +18,22 @@ from the repository root:
 
 ## Sample client
 
-A WebSocket client requires a host, port, and resource (a.k.a. path). This
-example client sends a text message and then disconnects.
+The following example demonstrates opening a WebSocket by URL. The connection
+may also be opened with `open_websocket(…)`, which takes a host, port, and
+resource as arguments.
 
     import trio
-    from trio_websocket import WebSocketServer, ConnectionClosed
+    from trio_websocket import open_websocket_url
 
 
     async def main():
         async with trio.open_nursery() as nursery:
-            client = WebSocketClient(args.host, args.port, args.resource,
-                use_ssl=False)
             try:
-                connection = await client.connect(nursery)
+                async with open_websocket_url(nursery, 'ws://localhost/foo') as conn:
+                    await conn.send_message('hello world!')
             except OSError as ose:
                 logging.error('Connection attempt failed: %s', ose)
                 return
-            await connection.send_message('hello world!')
-            await connection.close()
 
     trio.run(main)
 

--- a/examples/client.py
+++ b/examples/client.py
@@ -44,7 +44,7 @@ def parse_args():
 async def main(args):
     ''' Main entry point, returning False in the case of logged error. '''
     async with trio.open_nursery() as nursery:
-        logging.info('Connecting to WebSocket…')
+        logging.debug('Connecting to WebSocket…')
         ssl_context = ssl.create_default_context()
         if args.ssl:
             try:
@@ -63,10 +63,10 @@ async def main(args):
         except OSError as ose:
             logging.error('Connection attempt failed: %s', ose)
             return False
-        logging.info('Connected!')
+        logging.debug('Connected!')
         async with connection:
             await handle_connection(connection)
-        logging.info('Connection closed')
+        logging.debug('Connection closed')
 
 
 async def handle_connection(connection):

--- a/examples/client.py
+++ b/examples/client.py
@@ -12,7 +12,8 @@ import ssl
 import sys
 
 import trio
-from trio_websocket import WebSocketClient, ConnectionClosed
+from trio_websocket import open_websocket_url, ConnectionClosed
+import yarl
 
 
 logging.basicConfig(level=logging.DEBUG)
@@ -33,40 +34,34 @@ def commands():
 def parse_args():
     ''' Parse command line arguments. '''
     parser = argparse.ArgumentParser(description='Example trio-websocket client')
-    parser.add_argument('--ssl', action='store_true', help='Use SSL')
-    parser.add_argument('host', help='Host to connect to')
-    parser.add_argument('port', type=int, help='Port to connect to')
-    parser.add_argument('resource', help='Path to access on server (without'
-        ' leading slash)')
+    parser.add_argument('url', help='WebSocket URL to connect to')
     return parser.parse_args()
 
 
 async def main(args):
     ''' Main entry point, returning False in the case of logged error. '''
     async with trio.open_nursery() as nursery:
-        logging.debug('Connecting to WebSocket…')
-        ssl_context = ssl.create_default_context()
-        if args.ssl:
+        if yarl.URL(args.url).scheme == 'wss':
+            # Configure SSL context to handle our self-signed certificate. Most
+            # clients won't need to do this.
             try:
+                ssl_context = ssl.create_default_context()
                 ssl_context.load_verify_locations(here / 'fake.ca.pem')
             except FileNotFoundError:
                 logging.error('Did not find file "fake.ca.pem". You need to run'
                     ' generate-cert.py')
                 return False
-            client = WebSocketClient(args.host, args.port, args.resource,
-                use_ssl=ssl_context)
         else:
-            client = WebSocketClient(args.host, args.port, args.resource,
-                use_ssl=False)
+            ssl_context = None
         try:
-            connection = await client.connect(nursery)
+            logging.debug('Connecting to WebSocket…')
+            async with open_websocket_url(nursery, args.url, ssl_context) as conn:
+                logging.debug('Connected!')
+                await handle_connection(conn)
+            logging.debug('Connection closed')
         except OSError as ose:
             logging.error('Connection attempt failed: %s', ose)
             return False
-        logging.debug('Connected!')
-        async with connection:
-            await handle_connection(connection)
-        logging.debug('Connection closed')
 
 
 async def handle_connection(connection):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+trio_mode = true

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     ],
     keywords='websocket client server trio',
     packages=find_packages(exclude=['docs', 'examples', 'tests']),
-    install_requires=['async_generator', 'trio', 'wsaccel', 'wsproto'],
+    install_requires=['async_generator', 'trio', 'wsaccel', 'wsproto', 'yarl'],
     extras_require={
         'dev': ['pytest', 'pytest-trio', 'trustme'],
     },

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     ],
     keywords='websocket client server trio',
     packages=find_packages(exclude=['docs', 'examples', 'tests']),
-    install_requires=['trio', 'wsaccel', 'wsproto'],
+    install_requires=['async_generator', 'trio', 'wsaccel', 'wsproto'],
     extras_require={
         'dev': ['pytest', 'pytest-trio', 'trustme'],
     },

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,9 @@ setup(
     ],
     keywords='websocket client server trio',
     packages=find_packages(exclude=['docs', 'examples', 'tests']),
-    install_requires=['trio', 'trustme', 'wsproto'],
+    install_requires=['trio', 'wsaccel', 'wsproto'],
     extras_require={
-        'wsaccel': ['wsaccel'],
+        'dev': ['pytest', 'pytest-trio', 'trustme'],
     },
     project_urls={
         'Bug Reports': 'https://github.com/HyperionGray/trio-websocket/issues',

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,0 +1,52 @@
+import pytest
+from trio_websocket import ConnectionClosed, WebSocketClient, WebSocketServer
+import trio
+
+
+import logging
+logging.basicConfig(level=logging.DEBUG)
+
+
+@pytest.fixture
+async def echo_server(nursery):
+    async def handler(conn):
+        try:
+            msg = await conn.get_message()
+            await conn.send_message(msg)
+        except ConnectionClosed:
+            pass
+    server = WebSocketServer(handler, 'localhost', 0, ssl_context=None)
+    await nursery.start(server.listen)
+    yield server
+
+
+def client_for_server(server):
+    ''' Create a client configured to connect to ``server``. '''
+    return WebSocketClient('localhost', server.port, 'resource', use_ssl=False)
+
+
+async def test_client_send_and_receive(echo_server, nursery):
+    client = client_for_server(echo_server)
+    conn = await client.connect(nursery)
+    await conn.send_message('This is a test message.')
+    received_msg = await conn.get_message()
+    assert received_msg == 'This is a test message.'
+    await conn.close()
+
+
+async def test_client_default_close(echo_server, nursery):
+    client = client_for_server(echo_server)
+    conn = await client.connect(nursery)
+    assert conn.closed is None
+    await conn.close()
+    assert conn.closed.code == 1000
+    assert conn.closed.reason is None
+
+
+async def test_client_nondefault_close(echo_server, nursery):
+    client = client_for_server(echo_server)
+    conn = await client.connect(nursery)
+    assert conn.closed is None
+    await conn.close(code=1001, reason='test reason')
+    assert conn.closed.code == 1001
+    assert conn.closed.reason == 'test reason'

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,5 +1,6 @@
 import pytest
-from trio_websocket import ConnectionClosed, open_websocket, WebSocketServer
+from trio_websocket import ConnectionClosed, open_websocket, \
+    open_websocket_url, WebSocketServer
 import trio
 
 
@@ -31,6 +32,18 @@ async def echo_conn(echo_server, nursery):
     async with open_websocket(nursery, HOST, echo_server.port, RESOURCE,
         use_ssl=False) as conn:
         yield conn
+
+
+async def test_client_open_url(echo_server, nursery):
+    url = 'ws://{}:{}/{}'.format(HOST, echo_server.port, RESOURCE)
+    async with open_websocket_url(nursery, url) as conn:
+        assert conn.path == RESOURCE
+
+
+async def test_client_open_invalid_url(echo_server, nursery):
+    with pytest.raises(ValueError):
+        async with open_websocket_url(nursery, 'http://foo.com/bar') as conn:
+            pass
 
 
 async def test_client_send_and_receive(echo_conn, nursery):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,5 +1,5 @@
 import pytest
-from trio_websocket import ConnectionClosed, WebSocketClient, WebSocketServer
+from trio_websocket import ConnectionClosed, open_websocket, WebSocketServer
 import trio
 
 
@@ -28,8 +28,8 @@ async def echo_server(nursery):
 async def echo_conn(echo_server, nursery):
     ''' Return a client connection instance that is connected to an echo
     server. '''
-    client = WebSocketClient(HOST, echo_server.port, RESOURCE, use_ssl=False)
-    async with await client.connect(nursery) as conn:
+    async with open_websocket(nursery, HOST, echo_server.port, RESOURCE,
+        use_ssl=False) as conn:
         yield conn
 
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -5,6 +5,8 @@ import trio
 
 import logging
 logging.basicConfig(level=logging.DEBUG)
+HOST = 'localhost'
+RESOURCE = 'resource'
 
 
 @pytest.fixture
@@ -15,38 +17,36 @@ async def echo_server(nursery):
             await conn.send_message(msg)
         except ConnectionClosed:
             pass
-    server = WebSocketServer(handler, 'localhost', 0, ssl_context=None)
+    server = WebSocketServer(handler, HOST, 0, ssl_context=None)
     await nursery.start(server.listen)
     yield server
 
 
 def client_for_server(server):
     ''' Create a client configured to connect to ``server``. '''
-    return WebSocketClient('localhost', server.port, 'resource', use_ssl=False)
+    return WebSocketClient(HOST, server.port, RESOURCE, use_ssl=False)
 
 
 async def test_client_send_and_receive(echo_server, nursery):
     client = client_for_server(echo_server)
-    conn = await client.connect(nursery)
-    await conn.send_message('This is a test message.')
-    received_msg = await conn.get_message()
-    assert received_msg == 'This is a test message.'
-    await conn.close()
+    async with await client.connect(nursery) as conn:
+        await conn.send_message('This is a test message.')
+        received_msg = await conn.get_message()
+        assert received_msg == 'This is a test message.'
 
 
 async def test_client_default_close(echo_server, nursery):
     client = client_for_server(echo_server)
-    conn = await client.connect(nursery)
-    assert conn.closed is None
-    await conn.close()
+    async with await client.connect(nursery) as conn:
+        assert conn.closed is None
     assert conn.closed.code == 1000
     assert conn.closed.reason is None
 
 
 async def test_client_nondefault_close(echo_server, nursery):
     client = client_for_server(echo_server)
-    conn = await client.connect(nursery)
-    assert conn.closed is None
-    await conn.close(code=1001, reason='test reason')
+    async with await client.connect(nursery) as conn:
+        assert conn.closed is None
+        await conn.aclose(code=1001, reason='test reason')
     assert conn.closed.code == 1001
     assert conn.closed.reason == 'test reason'

--- a/trio_websocket/__init__.py
+++ b/trio_websocket/__init__.py
@@ -330,7 +330,8 @@ class WebSocketConnection(trio.abc.AsyncResource):
                         event_type)
                     await handler(event)
                 except KeyError:
-                    logger.error('Received unknown event type: %s', event_type)
+                    logger.warning('Received unknown event type: %s',
+                        event_type)
 
             # Get network data.
             try:

--- a/trio_websocket/__init__.py
+++ b/trio_websocket/__init__.py
@@ -4,6 +4,7 @@ import logging
 import ssl
 from functools import partial
 
+from async_generator import async_generator, yield_, asynccontextmanager
 import trio
 import trio.abc
 import wsproto.connection as wsconnection
@@ -14,6 +15,51 @@ import wsproto.frame_protocol as wsframeproto
 __version__ = '0.2.0-dev'
 RECEIVE_BYTES = 4096
 logger = logging.getLogger('trio-websocket')
+
+
+@asynccontextmanager
+@async_generator
+async def open_websocket(nursery, host, port, resource, use_ssl):
+    '''
+    Open a WebSocket client connection to a host.
+
+    This function is an async context manager that automatically connects and
+    disconnects. It yields a `WebSocketConnection` instance.
+
+    :param nursery: a trio Nursery to run background tasks in
+    :param str host: the host to connect to
+    :param int port: the port to connect to
+    :param str resource: the resource (i.e. path without leading slash)
+    :param use_ssl: a bool or SSLContext
+    '''
+
+    if use_ssl == True:
+        ssl_context = ssl.create_default_context()
+    elif use_ssl == False:
+        ssl_context = None
+    elif isinstance(use_ssl, ssl.SSLContext):
+        ssl_context = use_ssl
+    else:
+        raise TypeError('`use_ssl` argument must be bool or ssl.SSLContext')
+
+    logger.debug('Connecting to ws%s://%s:%d/%s',
+        '' if ssl_context is None else 's', host, port, resource)
+    if ssl_context is None:
+        stream = await trio.open_tcp_stream(host, port)
+    else:
+        stream = await trio.open_ssl_over_tcp_stream(host, port,
+            ssl_context=ssl_context, https_compatible=True)
+    if port in (80, 443):
+        host_header = host
+    else:
+        host_header = '{}:{}'.format(host, port)
+    wsproto = wsconnection.WSConnection(wsconnection.CLIENT, host=host_header,
+        resource=resource)
+    connection = WebSocketConnection(stream, wsproto, path=resource)
+    nursery.start_soon(connection._reader_task)
+    await connection._open_handshake.wait()
+    async with connection:
+        await yield_(connection)
 
 
 class ConnectionClosed(Exception):
@@ -432,55 +478,3 @@ class WebSocketServer:
             nursery.start_soon(self._handler, connection)
 
 
-class WebSocketClient:
-    ''' WebSocket client. '''
-
-    def __init__(self, host, port, resource, use_ssl):
-        '''
-        Constructor.
-
-        :param str host: the host to connect to
-        :param int port: the port to connect to
-        :param str resource: the resource (i.e. path without leading slash)
-        :param use_ssl: a bool or SSLContext
-        '''
-        self._host = host
-        self._port = port
-        self._resource = resource
-        if use_ssl == True:
-            self._ssl = ssl.create_default_context()
-        elif use_ssl == False:
-            self._ssl = None
-        elif isinstance(use_ssl, ssl.SSLContext):
-            self._ssl = use_ssl
-        else:
-            raise TypeError('`use_ssl` argument must be bool or ssl.SSLContext')
-
-    async def connect(self, nursery):
-        '''
-        Connect to WebSocket server.
-
-        The connection will be returned once the HTTP handshake is successful.
-
-        :param nursery: a Trio nursery to run background connection tasks in
-        :return: a WebSocketConnection
-        :raises: OSError if connection attempt fails
-        '''
-        logger.debug('Connecting to http%s://%s:%d/%s',
-            '' if self._ssl is None else 's', self._host, self._port,
-            self._resource)
-        if self._ssl is None:
-            stream = await trio.open_tcp_stream(self._host, self._port)
-        else:
-            stream = await trio.open_ssl_over_tcp_stream(self._host,
-                self._port, ssl_context=self._ssl, https_compatible=True)
-        if self._port in (80, 443):
-            host_header = self._host
-        else:
-            host_header = '{}:{}'.format(self._host, self._port)
-        wsproto = wsconnection.WSConnection(wsconnection.CLIENT,
-            host=host_header, resource=self._resource)
-        connection = WebSocketConnection(stream, wsproto, path=self._resource)
-        nursery.start_soon(connection._reader_task)
-        await connection._open_handshake.wait()
-        return connection


### PR DESCRIPTION
As mentioned in #24, the `WebSocketClient` class is a confusing and unnecessary part of the API. This PR replaces that class with a context manager. It also adds support for opening a WebSocket by URL.