### PR TITLE
Make the client's nursery argument optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,12 @@ resource as arguments.
 
 
     async def main():
-        async with trio.open_nursery() as nursery:
-            try:
-                async with open_websocket_url(nursery, 'ws://localhost/foo') as conn:
-                    await conn.send_message('hello world!')
-            except OSError as ose:
-                logging.error('Connection attempt failed: %s', ose)
-                return
+        try:
+            async with open_websocket_url('ws://localhost/foo') as conn:
+                await conn.send_message('hello world!')
+        except OSError as ose:
+            logging.error('Connection attempt failed: %s', ose)
+            return
 
     trio.run(main)
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -7,7 +7,7 @@ import trio
 
 
 HOST = 'localhost'
-RESOURCE = 'resource'
+RESOURCE = '/resource'
 
 
 @pytest.fixture
@@ -35,13 +35,13 @@ async def echo_conn(echo_server):
 
 
 async def test_client_open_url(echo_server):
-    url = 'ws://{}:{}/{}'.format(HOST, echo_server.port, RESOURCE)
+    url = 'ws://{}:{}{}?foo=bar'.format(HOST, echo_server.port, RESOURCE)
     async with open_websocket_url(url) as conn:
-        assert conn.path == RESOURCE
+        assert conn.path == RESOURCE + '?foo=bar'
 
 
 async def test_client_open_in_nursery(echo_server, nursery):
-    url = 'ws://{}:{}/{}'.format(HOST, echo_server.port, RESOURCE)
+    url = 'ws://{}:{}{}'.format(HOST, echo_server.port, RESOURCE)
     async with open_websocket_url(url, nursery=nursery) as conn:
         assert len(nursery.child_tasks) == 1
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,11 +1,11 @@
+import logging
+
 import pytest
 from trio_websocket import ConnectionClosed, open_websocket, \
     open_websocket_url, WebSocketServer
 import trio
 
 
-import logging
-logging.basicConfig(level=logging.DEBUG)
 HOST = 'localhost'
 RESOURCE = 'resource'
 
@@ -26,41 +26,47 @@ async def echo_server(nursery):
 
 
 @pytest.fixture
-async def echo_conn(echo_server, nursery):
+async def echo_conn(echo_server):
     ''' Return a client connection instance that is connected to an echo
     server. '''
-    async with open_websocket(nursery, HOST, echo_server.port, RESOURCE,
-        use_ssl=False) as conn:
+    async with open_websocket(HOST, echo_server.port, RESOURCE, use_ssl=False) \
+        as conn:
         yield conn
 
 
-async def test_client_open_url(echo_server, nursery):
+async def test_client_open_url(echo_server):
     url = 'ws://{}:{}/{}'.format(HOST, echo_server.port, RESOURCE)
-    async with open_websocket_url(nursery, url) as conn:
+    async with open_websocket_url(url) as conn:
         assert conn.path == RESOURCE
 
 
-async def test_client_open_invalid_url(echo_server, nursery):
+async def test_client_open_in_nursery(echo_server, nursery):
+    url = 'ws://{}:{}/{}'.format(HOST, echo_server.port, RESOURCE)
+    async with open_websocket_url(url, nursery=nursery) as conn:
+        assert len(nursery.child_tasks) == 1
+
+
+async def test_client_open_invalid_url(echo_server):
     with pytest.raises(ValueError):
-        async with open_websocket_url(nursery, 'http://foo.com/bar') as conn:
+        async with open_websocket_url('http://foo.com/bar') as conn:
             pass
 
 
-async def test_client_send_and_receive(echo_conn, nursery):
+async def test_client_send_and_receive(echo_conn):
     async with echo_conn:
         await echo_conn.send_message('This is a test message.')
         received_msg = await echo_conn.get_message()
         assert received_msg == 'This is a test message.'
 
 
-async def test_client_default_close(echo_conn, nursery):
+async def test_client_default_close(echo_conn):
     async with echo_conn:
         assert echo_conn.closed is None
     assert echo_conn.closed.code == 1000
     assert echo_conn.closed.reason is None
 
 
-async def test_client_nondefault_close(echo_conn, nursery):
+async def test_client_nondefault_close(echo_conn):
     async with echo_conn:
         assert echo_conn.closed is None
         await echo_conn.aclose(code=1001, reason='test reason')

--- a/trio_websocket/__init__.py
+++ b/trio_websocket/__init__.py
@@ -20,18 +20,19 @@ logger = logging.getLogger('trio-websocket')
 
 @asynccontextmanager
 @async_generator
-async def open_websocket(nursery, host, port, resource, use_ssl):
+async def open_websocket(host, port, resource, use_ssl, nursery=None):
     '''
     Open a WebSocket client connection to a host.
 
     This function is an async context manager that automatically connects and
     disconnects. It yields a `WebSocketConnection` instance.
 
-    :param nursery: a trio Nursery to run background tasks in
     :param str host: the host to connect to
     :param int port: the port to connect to
     :param str resource: the resource (i.e. path without leading slash)
     :param use_ssl: a bool or SSLContext
+    :param nursery: optional Trio nursery to run background tasks in, if not
+        provided, then a new nursery will be created
     '''
 
     if use_ssl == True:
@@ -54,18 +55,29 @@ async def open_websocket(nursery, host, port, resource, use_ssl):
         host_header = host
     else:
         host_header = '{}:{}'.format(host, port)
-    wsproto = wsconnection.WSConnection(wsconnection.CLIENT, host=host_header,
-        resource=resource)
+    wsproto = wsconnection.WSConnection(wsconnection.CLIENT,
+        host=host_header, resource=resource)
     connection = WebSocketConnection(stream, wsproto, path=resource)
-    nursery.start_soon(connection._reader_task)
-    await connection._open_handshake.wait()
-    async with connection:
-        await yield_(connection)
+
+    async def connect_in_nursery(connection, nursery):
+        nursery.start_soon(connection._reader_task)
+        await connection._open_handshake.wait()
+        return connection
+
+    if nursery is None:
+        async with trio.open_nursery() as new_nursery:
+            connection = await connect_in_nursery(connection, new_nursery)
+            async with connection:
+                await yield_(connection)
+    else:
+        connection = await connect_in_nursery(connection, nursery)
+        async with connection:
+            await yield_(connection)
 
 
 @asynccontextmanager
 @async_generator
-async def open_websocket_url(nursery, url, ssl_context=None):
+async def open_websocket_url(url, ssl_context=None, nursery=None):
     '''
     Open a WebSocket client connection to a URL.
 
@@ -74,6 +86,8 @@ async def open_websocket_url(nursery, url, ssl_context=None):
 
     :param str url: a WebSocket URL
     :param ssl_context: optional SSLContext, only used for wss: URL scheme
+    :param nursery: optional Trio nursery to run background tasks in, if not
+        provided, then a new nursery will be created
     '''
     url = URL(url)
     if url.scheme not in ('ws', 'wss'):
@@ -83,7 +97,7 @@ async def open_websocket_url(nursery, url, ssl_context=None):
         use_ssl = url.scheme == 'wss'
     else:
         use_ssl = ssl_context
-    async with open_websocket(nursery, url.host, url.port, resource, use_ssl) \
+    async with open_websocket(url.host, url.port, resource, use_ssl, nursery) \
         as conn:
         await yield_(conn)
 


### PR DESCRIPTION
This fixes #20. The `nursery` argument is optional. If specified, the reader task is spawned in that nursery, otherwise it creates an internal nursery.