### PR TITLE
Arbitrary listeners and streams

### DIFF
--- a/examples/server.py
+++ b/examples/server.py
@@ -15,7 +15,7 @@ import ssl
 import sys
 
 import trio
-from trio_websocket import WebSocketServer, ConnectionClosed
+from trio_websocket import serve_websocket, ConnectionClosed
 
 
 logging.basicConfig(level=logging.DEBUG)
@@ -27,7 +27,7 @@ def parse_args():
     ''' Parse command line arguments. '''
     parser = argparse.ArgumentParser(description='Example trio-websocket client')
     parser.add_argument('--ssl', action='store_true', help='Use SSL')
-    parser.add_argument('ip', help='IP to bind to')
+    parser.add_argument('host', help='Host interface to bind to (all)')
     parser.add_argument('port', type=int, help='Port to bind to')
     return parser.parse_args()
 
@@ -44,9 +44,8 @@ async def main(args):
                 ' generate-cert.py')
     else:
         ssl_context = None
-    server = WebSocketServer(handler, args.ip, args.port,
-        ssl_context=ssl_context)
-    await server.listen()
+    host = args.host if args.host == '' else None
+    await serve_websocket(handler, host, args.port, ssl_context)
 
 
 async def handler(websocket):

--- a/examples/server.py
+++ b/examples/server.py
@@ -27,7 +27,8 @@ def parse_args():
     ''' Parse command line arguments. '''
     parser = argparse.ArgumentParser(description='Example trio-websocket client')
     parser.add_argument('--ssl', action='store_true', help='Use SSL')
-    parser.add_argument('host', help='Host interface to bind to (all)')
+    parser.add_argument('host', help='Host interface to bind to (* binds to all'
+        'interfaces)')
     parser.add_argument('port', type=int, help='Port to bind to')
     return parser.parse_args()
 
@@ -44,7 +45,7 @@ async def main(args):
                 ' generate-cert.py')
     else:
         ssl_context = None
-    host = args.host if args.host == '' else None
+    host = None if args.host == '*' else args.host
     await serve_websocket(handler, host, args.port, ssl_context)
 
 

--- a/examples/server.py
+++ b/examples/server.py
@@ -27,9 +27,9 @@ def parse_args():
     ''' Parse command line arguments. '''
     parser = argparse.ArgumentParser(description='Example trio-websocket client')
     parser.add_argument('--ssl', action='store_true', help='Use SSL')
-    parser.add_argument('host', help='Host interface to bind to (* binds to all'
-        'interfaces)')
-    parser.add_argument('port', type=int, help='Port to bind to')
+    parser.add_argument('host', help='Host interface to bind. If omitted, '
+        'then bind all interfaces.', nargs='?')
+    parser.add_argument('port', type=int, help='Port to bind.')
     return parser.parse_args()
 
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,15 @@ setup(
     ],
     keywords='websocket client server trio',
     packages=find_packages(exclude=['docs', 'examples', 'tests']),
-    install_requires=['async_generator', 'trio', 'wsaccel', 'wsproto', 'yarl'],
+    install_requires=[
+        'async_generator',
+        'attrs',
+        'ipaddress',
+        'trio',
+        'wsaccel',
+        'wsproto',
+        'yarl'
+    ],
     extras_require={
         'dev': ['pytest', 'pytest-trio', 'trustme'],
     },

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -223,8 +223,7 @@ async def test_client_nondefault_close(echo_conn):
 
 async def test_wrap_client_stream(echo_server, nursery):
     stream = await trio.open_tcp_stream(HOST, echo_server.port)
-    conn = await nursery.start(wrap_client_stream, nursery, stream, HOST,
-        RESOURCE)
+    conn = await wrap_client_stream(nursery, stream, HOST, RESOURCE)
     async with conn:
         assert not conn.closed
         await conn.send_message('Hello from client!')
@@ -235,7 +234,7 @@ async def test_wrap_client_stream(echo_server, nursery):
 
 async def test_wrap_server_stream(nursery):
     async def handler(stream):
-        server = await nursery.start(wrap_server_stream, nursery, stream)
+        server = await wrap_server_stream(nursery, stream)
         async with server:
             assert not server.closed
             msg = await server.get_message()

--- a/trio_websocket/__init__.py
+++ b/trio_websocket/__init__.py
@@ -615,10 +615,15 @@ class WebSocketServer:
         This property only works if you have a single listener, and that
         listener must be socket-based.
         """
-        if len(self._listeners) != 1:
+        if len(self._listeners) > 1:
             raise RuntimeError('Cannot get port because this server has'
                 ' more than 1 listeners.')
-        return self.listeners[0].port
+        try:
+            listener = self.listeners[0]
+            return listener.port
+        except AttributeError:
+            raise RuntimeError('This socket does not have a port: {!r}'
+                .format(listener)) from None
 
     @property
     def listeners(self):


### PR DESCRIPTION
This implements #2 with the following features:

* Handle multiple listeners correctly: before this PR, if you had multiple listeners, i.e. `host=None` and you get an IPv4 listener and an IPv6 listener, then the log message would only show the first listener and the `port` property would only work on the first listener. Now multiple listeners are logged correctly and a new `listeners` property exposes metadata about each listener. The old `port` property is still there for convenience when using a single TCP listener.
* Factor listener out of server code: the server now takes a list of listeners instead of host/port/etc. A new `serve_tcp()` function takes host/port/etc. and constructs a server instance.
* Add functions that take an arbitrary stream and wrap them in a `WebSocketConnection`.
