### PR TITLE
Example client handle close

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -274,3 +274,12 @@ async def test_server_does_not_close_handshake(nursery):
     async with open_websocket(HOST, port, RESOURCE, use_ssl=False) as client:
         with pytest.raises(ConnectionClosed):
             await client.get_message()
+
+
+async def test_connection_cancel_scope(echo_server):
+    async with trio.open_nursery() as nursery:
+        async with open_websocket(HOST, echo_server.port, RESOURCE,
+            use_ssl=False, cancel_scope=nursery.cancel_scope) as conn:
+            pass
+        await trio.sleep(0)
+    assert nursery.cancel_scope.cancel_called


### PR DESCRIPTION
This is one possible solution to #22: add an optional `cancel_scope` argument to client connections. When the connection is closed, the scope is cancelled. This allows, among other things, the example client to exit immediately when the server closes the connection. Previously, the example client would block on waiting for command line input and would not notice the connection dropped until it tried to perform the next command.