### PR TITLE
example client: cancel command loop on close of connection

### DIFF
--- a/examples/client.py
+++ b/examples/client.py
@@ -54,10 +54,12 @@ async def main(args):
         ssl_context = None
     try:
         logging.debug('Connecting to WebSocket…')
-        async with open_websocket_url(args.url, ssl_context) as conn:
-            logging.debug('Connected!')
-            await handle_connection(conn)
-        logging.debug('Connection closed')
+        async with trio.open_nursery() as nursery:
+            async with open_websocket_url(args.url, ssl_context) as conn:
+                logging.debug('Connected!')
+                nursery.start_soon(handle_connection, conn)
+            logging.debug('Connection closed')
+            nursery.cancel_scope.cancel()
     except OSError as ose:
         logging.error('Connection attempt failed: %s', ose)
         return False


### PR DESCRIPTION
Intended to fix #22.

It does handle the connection close cases fine.  However it somehow breaks normal communication.  Before this change, here is server-side log from "send foo":
```
DEBUG:trio-websocket:conn#1 received 9 bytes
DEBUG:trio-websocket:conn#1 received event: TextReceived
DEBUG:trio-websocket:conn#1 sending 5 bytes
```
With this change, the server gets the bytes but appears to not recognize the end of the message, so never reponds:
```
DEBUG:trio-websocket:conn#2 received 9 bytes
```