### PR TITLE
Allow more control over handshake (#4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ from trio_websocket import open_websocket_url
 
 async def main():
     try:
-        async with open_websocket_url('ws://localhost/foo') as conn:
-            await conn.send_message('hello world!')
+        async with open_websocket_url('ws://localhost/foo') as ws:
+            await ws.send_message('hello world!')
     except OSError as ose:
         logging.error('Connection attempt failed: %s', ose)
 
@@ -61,11 +61,12 @@ to each incoming message with an identical outgoing message.
 import trio
 from trio_websocket import serve_websocket, ConnectionClosed
 
-async def echo_server(websocket):
+async def echo_server(request):
+    ws = await request.accept()
     while True:
         try:
-            message = await websocket.get_message()
-            await websocket.send_message(message)
+            message = await ws.get_message()
+            await ws.send_message(message)
         except ConnectionClosed:
             break
 

--- a/examples/server.py
+++ b/examples/server.py
@@ -49,13 +49,14 @@ async def main(args):
     await serve_websocket(handler, host, args.port, ssl_context)
 
 
-async def handler(websocket):
+async def handler(request):
     ''' Reverse incoming websocket messages and send them back. '''
-    logging.info('Handler starting (path=%s)' % websocket.path)
+    logging.info('Handler starting on path "%s"' % request.url.path_qs)
+    ws = await request.accept()
     while True:
         try:
-            message = await websocket.get_message()
-            await websocket.send_message(message[::-1])
+            message = await ws.get_message()
+            await ws.send_message(message[::-1])
         except ConnectionClosed:
             logging.info('Connection closed')
             break

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -28,7 +28,8 @@ RESOURCE = '/resource'
 async def echo_server(nursery):
     ''' A server that reads one message, sends back the same message,
     then closes the connection. '''
-    serve_fn = partial(serve_websocket, echo_handler, HOST, 0, ssl_context=None)
+    serve_fn = partial(serve_websocket, echo_request_handler, HOST, 0,
+        ssl_context=None)
     server = await nursery.start(serve_fn)
     await yield_(server)
 
@@ -38,12 +39,20 @@ async def echo_server(nursery):
 async def echo_conn(echo_server):
     ''' Return a client connection instance that is connected to an echo
     server. '''
-    async with open_websocket(HOST, echo_server.port, RESOURCE, use_ssl=False) \
-            as conn:
+    async with open_websocket(HOST, echo_server.port, RESOURCE,
+            use_ssl=False) as conn:
         await yield_(conn)
 
 
-async def echo_handler(conn):
+async def echo_request_handler(request):
+    '''
+    Accept incoming request and then pass off to echo connection handler.
+    '''
+    conn = await request.accept()
+    await echo_conn_handler(conn)
+
+
+async def echo_conn_handler(conn):
     ''' A connection handler that reads one message, sends back the same
     message, then exits. '''
     try:
@@ -95,14 +104,16 @@ async def test_listen_port_ipv6():
 
 
 async def test_server_has_listeners(nursery):
-    server = await nursery.start(serve_websocket, echo_handler, HOST, 0, None)
+    server = await nursery.start(serve_websocket, echo_request_handler, HOST, 0,
+        None)
     assert len(server.listeners) > 0
     assert isinstance(server.listeners[0], ListenPort)
 
 
 async def test_serve(nursery):
     task = trio.hazmat.current_task()
-    server = await nursery.start(serve_websocket, echo_handler, HOST, 0, None)
+    server = await nursery.start(serve_websocket, echo_request_handler, HOST, 0,
+        None)
     port = server.port
     assert server.port != 0
     # The server nursery begins with one task (server.listen).
@@ -123,17 +134,19 @@ async def test_serve_ssl(nursery):
     ca.configure_trust(client_context)
     cert = ca.issue_server_cert(HOST)
     cert.configure_cert(server_context)
-    server = await nursery.start(serve_websocket, echo_handler, HOST, 0,
+
+    server = await nursery.start(serve_websocket, echo_request_handler, HOST, 0,
         server_context)
     port = server.port
-    async with open_websocket(HOST, port, RESOURCE, client_context) as conn:
+    async with open_websocket(HOST, port, RESOURCE, use_ssl=client_context
+            ) as conn:
         assert not conn.is_closed
 
 
 async def test_serve_handler_nursery(nursery):
     task = trio.hazmat.current_task()
     async with trio.open_nursery() as handler_nursery:
-        serve_with_nursery = partial(serve_websocket, echo_handler,
+        serve_with_nursery = partial(serve_websocket, echo_request_handler,
             HOST, 0, None, handler_nursery=handler_nursery)
         server = await nursery.start(serve_with_nursery)
         port = server.port
@@ -149,12 +162,12 @@ async def test_serve_handler_nursery(nursery):
 async def test_serve_with_zero_listeners(nursery):
     task = trio.hazmat.current_task()
     with pytest.raises(ValueError):
-        server = WebSocketServer(echo_handler, [])
+        server = WebSocketServer(echo_request_handler, [])
 
 
 async def test_serve_non_tcp_listener(nursery):
     listeners = [MemoryListener()]
-    server = WebSocketServer(echo_handler, listeners)
+    server = WebSocketServer(echo_request_handler, listeners)
     await nursery.start(server.run)
     assert len(server.listeners) == 1
     with pytest.raises(RuntimeError):
@@ -166,7 +179,7 @@ async def test_serve_non_tcp_listener(nursery):
 async def test_serve_multiple_listeners(nursery):
     listener1 = (await trio.open_tcp_listeners(0, host=HOST))[0]
     listener2 = MemoryListener()
-    server = WebSocketServer(echo_handler, [listener1, listener2])
+    server = WebSocketServer(echo_request_handler, [listener1, listener2])
     await nursery.start(server.run)
     assert len(server.listeners) == 2
     with pytest.raises(RuntimeError):
@@ -210,6 +223,21 @@ async def test_client_connect_url(echo_server, nursery):
     assert not conn.is_closed
 
 
+async def test_handshake_subprotocol(nursery):
+    async def handler(request):
+        assert request.proposed_subprotocols == ('chat', 'file')
+        assert request.subprotocol is None
+        request.subprotocol = 'chat'
+        assert request.subprotocol == 'chat'
+        server_ws = await request.accept()
+        assert server_ws.subprotocol == 'chat'
+
+    server = await nursery.start(serve_websocket, handler, HOST, 0, None)
+    async with open_websocket(HOST, server.port, RESOURCE, use_ssl=False,
+        subprotocols=('chat', 'file')) as client_ws:
+        assert client_ws.subprotocol == 'chat'
+
+
 async def test_client_send_and_receive(echo_conn):
     async with echo_conn:
         await echo_conn.send_message('This is a test message.')
@@ -245,12 +273,13 @@ async def test_wrap_client_stream(echo_server, nursery):
 
 async def test_wrap_server_stream(nursery):
     async def handler(stream):
-        server = await wrap_server_stream(nursery, stream)
-        async with server:
-            assert not server.is_closed
-            msg = await server.get_message()
+        request = await wrap_server_stream(nursery, stream)
+        server_ws = await request.accept()
+        async with server_ws:
+            assert not server_ws.is_closed
+            msg = await server_ws.get_message()
             assert msg == 'Hello from client!'
-        assert server.is_closed
+        assert server_ws.is_closed
     serve_fn = partial(trio.serve_tcp, handler, 0, host=HOST)
     listeners = await nursery.start(serve_fn)
     port = listeners[0].socket.getsockname()[1]
@@ -259,26 +288,28 @@ async def test_wrap_server_stream(nursery):
 
 
 async def test_client_does_not_close_handshake(nursery):
-    async def handler(server):
+    async def handler(request):
+        server_ws = await request.accept()
         with pytest.raises(ConnectionClosed):
-            await server.get_message()
+            await server_ws.get_message()
     server = await nursery.start(serve_websocket, handler, HOST, 0, None)
     port = server.port
     stream = await trio.open_tcp_stream(HOST, server.port)
-    client = await wrap_client_stream(nursery, stream, HOST, RESOURCE)
-    async with client:
+    client_ws = await wrap_client_stream(nursery, stream, HOST, RESOURCE)
+    async with client_ws:
         await stream.aclose()
         with pytest.raises(ConnectionClosed):
-            await client.send_message('Hello from client!')
+            await client_ws.send_message('Hello from client!')
 
 
 async def test_server_does_not_close_handshake(nursery):
     async def handler(stream):
-        server = await wrap_server_stream(nursery, stream)
-        async with server:
+        request = await wrap_server_stream(nursery, stream)
+        server_ws = await request.accept()
+        async with server_ws:
             await stream.aclose()
             with pytest.raises(ConnectionClosed):
-                await server.send_message('Hello from client!')
+                await server_ws.send_message('Hello from client!')
     serve_fn = partial(trio.serve_tcp, handler, 0, host=HOST)
     listeners = await nursery.start(serve_fn)
     port = listeners[0].socket.getsockname()[1]
@@ -288,7 +319,8 @@ async def test_server_does_not_close_handshake(nursery):
 
 
 async def test_server_handler_exit(nursery, autojump_clock):
-    async def handler(connection):
+    async def handler(request):
+        server_ws = await request.accept()
         await trio.sleep(1)
 
     server = await nursery.start(

--- a/trio_websocket/__init__.py
+++ b/trio_websocket/__init__.py
@@ -22,7 +22,7 @@ logger = logging.getLogger('trio-websocket')
 
 @asynccontextmanager
 @async_generator
-async def open_websocket(host, port, resource, use_ssl):
+async def open_websocket(host, port, resource, *, use_ssl, subprotocols=None):
     '''
     Open a WebSocket client connection to a host.
 
@@ -38,15 +38,18 @@ async def open_websocket(host, port, resource, use_ssl):
     :param int port: the port to connect to
     :param str resource: the resource a.k.a. path
     :param use_ssl: a bool or SSLContext
+    :param subprotocols: An iterable of strings representing preferred
+        subprotocols.
     '''
     async with trio.open_nursery() as new_nursery:
         connection = await connect_websocket(new_nursery, host, port, resource,
-            use_ssl)
+            use_ssl=use_ssl, subprotocols=subprotocols)
         async with connection:
             await yield_(connection)
 
 
-async def connect_websocket(nursery, host, port, resource, use_ssl):
+async def connect_websocket(nursery, host, port, resource, *, use_ssl,
+    subprotocols=None):
     '''
     Return a WebSocket client connection to a host.
 
@@ -61,6 +64,8 @@ async def connect_websocket(nursery, host, port, resource, use_ssl):
     :param str resource: the resource a.k.a. path
     :param use_ssl: a bool or SSLContext
     :rtype: WebSocketConnection
+    :param subprotocols: An iterable of strings representing preferred
+        subprotocols.
     '''
     if use_ssl == True:
         ssl_context = ssl.create_default_context()
@@ -83,14 +88,14 @@ async def connect_websocket(nursery, host, port, resource, use_ssl):
     else:
         host_header = '{}:{}'.format(host, port)
     wsproto = wsconnection.WSConnection(wsconnection.CLIENT,
-        host=host_header, resource=resource)
+        host=host_header, resource=resource, subprotocols=subprotocols)
     connection = WebSocketConnection(stream, wsproto, path=resource)
     nursery.start_soon(connection._reader_task)
     await connection._open_handshake.wait()
     return connection
 
 
-def open_websocket_url(url, ssl_context=None):
+def open_websocket_url(url, ssl_context=None, *, subprotocols=None):
     '''
     Open a WebSocket client connection to a URL.
 
@@ -104,12 +109,16 @@ def open_websocket_url(url, ssl_context=None):
 
     :param str url: a WebSocket URL
     :param ssl_context: optional ``SSLContext`` used for ``wss:`` URLs
+    :param subprotocols: An iterable of strings representing preferred
+        subprotocols.
     '''
     host, port, resource, ssl_context = _url_to_host(url, ssl_context)
-    return open_websocket(host, port, resource, ssl_context)
+    return open_websocket(host, port, resource, use_ssl=ssl_context,
+        subprotocols=subprotocols)
 
 
-async def connect_websocket_url(nursery, url, ssl_context=None):
+async def connect_websocket_url(nursery, url, ssl_context=None, *,
+    subprotocols=None):
     '''
     Return a WebSocket client connection to a URL.
 
@@ -125,9 +134,12 @@ async def connect_websocket_url(nursery, url, ssl_context=None):
     :param ssl_context: optional ``SSLContext`` used for ``wss:`` URLs
     :param nursery: a Trio nursery to run background tasks in
     :rtype: WebSocketConnection
+    :param subprotocols: An iterable of strings representing preferred
+        subprotocols.
     '''
     host, port, resource, ssl_context = _url_to_host(url, ssl_context)
-    return await connect_websocket(nursery, host, port, resource, ssl_context)
+    return await connect_websocket(nursery, host, port, resource,
+        use_ssl=ssl_context, subprotocols=subprotocols)
 
 
 def _url_to_host(url, ssl_context):
@@ -153,7 +165,8 @@ def _url_to_host(url, ssl_context):
     return url.host, url.port, resource, ssl_context
 
 
-async def wrap_client_stream(nursery, stream, host, resource):
+async def wrap_client_stream(nursery, stream, host, resource, *,
+    subprotocols=None):
     '''
     Wrap an arbitrary stream in a client-side ``WebSocketConnection``.
 
@@ -165,10 +178,12 @@ async def wrap_client_stream(nursery, stream, host, resource):
     :param str host: A host string that will be sent in the ``Host:`` header.
     :param str resource: A resource string, i.e. the path component to be
         accessed on the server.
+    :param subprotocols: An iterable of strings representing preferred
+        subprotocols.
     :rtype: WebSocketConnection
     '''
     wsproto = wsconnection.WSConnection(wsconnection.CLIENT, host=host,
-        resource=resource)
+        resource=resource, subprotocols=subprotocols)
     connection = WebSocketConnection(stream, wsproto, path=resource)
     nursery.start_soon(connection._reader_task)
     await connection._open_handshake.wait()
@@ -177,7 +192,11 @@ async def wrap_client_stream(nursery, stream, host, resource):
 
 async def wrap_server_stream(nursery, stream):
     '''
-    Wrap an arbitrary stream in a server-side ``WebSocketConnection``.
+    Wrap an arbitrary stream in a server-side WebSocket.
+
+    The object returned is a ``WebSocketRequest``, which indicates the client's
+    proposed handshake. Call ``accept()`` on this object to obtain a
+    ``WebSocketConnection``.
 
     This is a low-level function only needed in rare cases. Most users should
     call ``serve_websocket()`.
@@ -185,13 +204,13 @@ async def wrap_server_stream(nursery, stream):
     :param nursery: A Trio nursery to run background tasks in.
     :param stream: A Trio stream to be wrapped.
     :param task_status: part of Trio nursery start protocol
-    :rtype: WebSocketConnection
+    :rtype: WebSocketRequest
     '''
     wsproto = wsconnection.WSConnection(wsconnection.SERVER)
     connection = WebSocketConnection(stream, wsproto)
     nursery.start_soon(connection._reader_task)
-    await connection._open_handshake.wait()
-    return connection
+    request = await connection._get_request()
+    return request
 
 
 async def serve_websocket(handler, host, port, ssl_context, *,
@@ -297,18 +316,129 @@ class CloseReason:
             self.code, self.name, self.reason)
 
 
+class Future:
+    ''' Represents a value that will be available in the future. '''
+    def __init__(self):
+        ''' Constructor. '''
+        self._value = None
+        self._value_event = trio.Event()
+
+    def set_value(self, value):
+        '''
+        Set a value, which will notify any waiters.
+
+        :param value:
+        '''
+        self._value = value
+        self._value_event.set()
+
+    async def wait_value(self):
+        '''
+        Wait for this future to have a value, then return it.
+
+        :returns: The value set by ``set_value()``.
+        '''
+        await self._value_event.wait()
+        return self._value
+
+
+class WebSocketRequest:
+    '''
+    Represents a handshake presented by a client to a server.
+
+    The server may modify the handshake or leave it as is. The server should
+    call ``accept()`` to finish the handshake and obtain a connection object.
+    '''
+    def __init__(self, accept_fn, event):
+        '''
+        Constructor.
+
+        :param accept_fn: A function to call that will finish the handshake and
+            return a ``WebSocketSconnection``.
+        :type event: wsproto.events.ConnectionRequested
+        '''
+        self._accept_fn = accept_fn
+        self._event = event
+        self._subprotocol = None
+
+    @property
+    def headers(self):
+        '''
+        A list of headers represented as (name, value) pairs.
+
+        :rtype: list
+        '''
+        return self._event.h11request.headers
+
+    @property
+    def proposed_subprotocols(self):
+        '''
+        A tuple of protocols proposed by the client.
+
+        :rtype: tuple[str]
+        '''
+        return tuple(self._event.proposed_subprotocols)
+
+    @property
+    def subprotocol(self):
+        '''
+        The selected protocol. Defaults to ``None``.
+
+        :rtype: str or None
+        '''
+        return self._subprotocol
+
+    @subprotocol.setter
+    def subprotocol(self, value):
+        '''
+        Set the selected protocol.
+
+        :type value: str or None
+        '''
+        self._subprotocol = value
+
+    @property
+    def url(self):
+        '''
+        The requested URL. Typically this URL does not contain a scheme, host,
+        or port.
+
+        :rtype yarl.URL:
+        '''
+        return URL(self._event.h11request.target.decode('ascii'))
+
+
+    async def accept(self):
+        '''
+        Finish the handshake with the terms contained in this request and
+        return a connection object.
+
+        :rtype: WebSocketConnection
+        '''
+        return await self._accept_fn(self)
+
+
 class WebSocketConnection(trio.abc.AsyncResource):
     ''' A WebSocket connection. '''
 
     CONNECTION_ID = itertools.count()
 
-    def __init__(self, stream, wsproto, path=None):
+    def __init__(self, stream, wsproto, *, path=None):
         '''
         Constructor.
 
+        Generally speaking, users are discouraged from directly instantiating a
+        ``WebSocketConnection`` and should instead use one of the convenience
+        functions in this module, e.g. ``open_websocket()`` or
+        ``serve_websocket()``. This class has some tricky internal logic and
+        timing that depends on whether it is an instance of a client connection
+        or a server connection. The convenience functions handle this complexity
+        for you.
+
         :param SocketStream stream:
-        :param wsproto: a WSConnection instance
-        :param client: a Trio cancel scope (only used by the server)
+        :type wsproto: wsproto.connection.WSConnection
+        :param str path: The URL path for this connection. Only used for server
+            instances.
         '''
         self._close_reason = None
         self._id = next(self.__class__.CONNECTION_ID)
@@ -319,7 +449,11 @@ class WebSocketConnection(trio.abc.AsyncResource):
         self._str_message = ''
         self._reader_running = True
         self._path = path
+        self._subprotocol = None
         self._put_channel, self._get_channel = open_channel(0)
+        # Set when the server has received a connection request event. This
+        # future is never set on client connections.
+        self._connection_proposal = Future()
         # Set once the WebSocket open handshake takes place, i.e.
         # ConnectionRequested for server or ConnectedEstablished for client.
         self._open_handshake = trio.Event()
@@ -353,6 +487,17 @@ class WebSocketConnection(trio.abc.AsyncResource):
     def path(self):
         """Returns the path from the HTTP handshake."""
         return self._path
+
+    @property
+    def subprotocol(self):
+        '''
+        Returns the negotiated subprotocol or ``None``.
+
+        This is only valid after the opening handshake is complete.
+
+        :rtype: str or None
+        '''
+        return self._subprotocol
 
     async def aclose(self, code=1000, reason=None):
         '''
@@ -445,6 +590,22 @@ class WebSocketConnection(trio.abc.AsyncResource):
         # (e.g. self.aclose()) to resume.
         self._close_handshake.set()
 
+    async def _accept(self, proposal):
+        '''
+        Accept a given proposal.
+
+        This finishes the server-side handshake with the given proposal
+        attributes and return the connection instance.
+
+        :rtype: WebSocketConnection
+        '''
+        self._subprotocol = proposal.subprotocol
+        self._path = proposal.url.path
+        self._wsproto.accept(proposal._event, self._subprotocol)
+        await self._write_pending()
+        self._open_handshake.set()
+        return self
+
     async def _close_stream(self):
         ''' Close the TCP connection. '''
         self._reader_running = False
@@ -465,16 +626,35 @@ class WebSocketConnection(trio.abc.AsyncResource):
         logger.debug('conn#%d websocket closed %r', self._id, exc)
         self._put_channel.close()
 
+    async def _get_request(self):
+        '''
+        Return a proposal for a WebSocket handshake.
+
+        This method can only be called on server connections and it may only be
+        called one time.
+
+        :rtype: WebSocketRequest
+        '''
+        if not self.is_server:
+            raise Exception('This method is only valid for server connections.')
+        if self._connection_proposal is None:
+            raise Exception('No proposal available. Did you call this method'
+                ' multiple times or at the wrong time?')
+        proposal = await self._connection_proposal.wait_value()
+        self._connection_proposal = None
+        return proposal
+
     async def _handle_connection_requested_event(self, event):
         '''
         Handle a ConnectionRequested event.
 
+        This method is async even though it never awaits, because the event
+        dispatch requires an async function.
+
         :param event:
         '''
-        self._path = event.h11request.target
-        self._wsproto.accept(event)
-        await self._write_pending()
-        self._open_handshake.set()
+        proposal = WebSocketRequest(self._accept, event)
+        self._connection_proposal.set_value(proposal)
 
     async def _handle_connection_established_event(self, event):
         '''
@@ -482,6 +662,7 @@ class WebSocketConnection(trio.abc.AsyncResource):
 
         :param event:
         '''
+        self._subprotocol = event.subprotocol
         self._open_handshake.set()
 
     async def _handle_connection_closed_event(self, event):
@@ -745,6 +926,5 @@ class WebSocketServer:
             connection = WebSocketConnection(stream, wsproto)
             nursery.start_soon(connection._reader_task)
             async with connection:
-                await connection._open_handshake.wait()
-                await self._handler(connection)
-            nursery.cancel_scope.cancel()
+                request = await connection._get_request()
+                await self._handler(request)


### PR DESCRIPTION
First attempt at this. Server handlers now receive a WebSocketRequest
instead of a WebSocketConnection. The request object provides the
client's handshake parameters and allows the server to finalize
handshake parameters. The server calls the requests ``accept()``
method to finish the handshake and obtain a connection object.

This first version exposes the request URL, headers, and subprotocols
to the server. The server is allowed to select a subprotocol. In future
versions (given support in wsproto), we can expand the request object
to customize headers and choose extensions.

In addition, the tests are updated: one new test to cover the
selection of a subprotocol, plus updates to existing tests to handle
the new request->connection step.

Finally, the README and example server are updated to show the new
request->connection step.