### PR TITLE
Delay connection closed (#69)

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -377,6 +377,61 @@ async def test_server_handler_exit(nursery, autojump_clock):
     with trio.fail_after(2):
         async with open_websocket(
                 HOST, server.port, '/', use_ssl=False) as connection:
-            with pytest.raises(ConnectionClosed) as e:
+            with pytest.raises(ConnectionClosed) as exc_info:
                 await connection.get_message()
-                assert e.reason.name == 'NORMAL_CLOSURE'
+            exc = exc_info.value
+            assert exc.reason.name == 'NORMAL_CLOSURE'
+
+
+async def test_read_messages_after_remote_close(nursery):
+    '''
+    When the remote endpoint closes, the local endpoint can still reading all
+    of the messages sent prior to closing. Any attempt to read beyond that will
+    raise ConnectionClosed.
+    '''
+    server_closed = trio.Event()
+
+    async def handler(request):
+        server = await request.accept()
+        async with server:
+            await server.send_message('1')
+            await server.send_message('2')
+        server_closed.set()
+
+    server = await nursery.start(
+        partial(serve_websocket, handler, HOST, 0, ssl_context=None))
+
+    async with open_websocket(HOST, server.port, '/', use_ssl=False) as client:
+        await server_closed.wait()
+        assert await client.get_message() == '1'
+        assert await client.get_message() == '2'
+        with pytest.raises(ConnectionClosed):
+            await client.get_message()
+
+
+async def test_no_messages_after_local_close(nursery):
+    '''
+    If the local endpoint initiates closing, then pending messages are discarded
+    and any attempt to read a message will raise ConnectionClosed.
+    '''
+    client_closed = trio.Event()
+
+    async def handler(request):
+        # The server sends some messages and then closes.
+        server = await request.accept()
+        async with server:
+            await server.send_message('1')
+            await server.send_message('2')
+            await client_closed.wait()
+
+    server = await nursery.start(
+        partial(serve_websocket, handler, HOST, 0, ssl_context=None))
+
+    # The client waits until the server closes (using an out-of-band trio Event)
+    # and then reads the messages. After reading all messages, it should raise
+    # ConnectionClosed.
+    async with open_websocket(HOST, server.port, '/', use_ssl=False) as client:
+        pass
+    with pytest.raises(ConnectionClosed):
+        await client.get_message()
+    client_closed.set()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -385,7 +385,7 @@ async def test_server_handler_exit(nursery, autojump_clock):
 
 async def test_read_messages_after_remote_close(nursery):
     '''
-    When the remote endpoint closes, the local endpoint can still reading all
+    When the remote endpoint closes, the local endpoint can still read all
     of the messages sent prior to closing. Any attempt to read beyond that will
     raise ConnectionClosed.
     '''

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -383,6 +383,7 @@ async def test_server_handler_exit(nursery, autojump_clock):
             assert exc.reason.name == 'NORMAL_CLOSURE'
 
 
+@pytest.mark.skip(reason='Hangs because channel size is hard coded to 0')
 async def test_read_messages_after_remote_close(nursery):
     '''
     When the remote endpoint closes, the local endpoint can still read all
@@ -427,9 +428,6 @@ async def test_no_messages_after_local_close(nursery):
     server = await nursery.start(
         partial(serve_websocket, handler, HOST, 0, ssl_context=None))
 
-    # The client waits until the server closes (using an out-of-band trio Event)
-    # and then reads the messages. After reading all messages, it should raise
-    # ConnectionClosed.
     async with open_websocket(HOST, server.port, '/', use_ssl=False) as client:
         pass
     with pytest.raises(ConnectionClosed):

--- a/trio_websocket/_impl.py
+++ b/trio_websocket/_impl.py
@@ -418,7 +418,8 @@ class WebSocketConnection(trio.abc.AsyncResource):
 
     CONNECTION_ID = itertools.count()
 
-    def __init__(self, stream, wsproto, *, path=None):
+    def __init__(self, stream, wsproto, *, path=None,
+            message_queue_size_do_not_use=2):
         '''
         Constructor.
 
@@ -445,7 +446,11 @@ class WebSocketConnection(trio.abc.AsyncResource):
         self._reader_running = True
         self._path = path
         self._subprotocol = None
-        self._send_channel, self._recv_channel = trio.open_memory_channel(32)
+        # TODO changed channel size from 0 to 2 temporarily to enable
+        # test_read_messages_after_remote_close to pass. The channel size will
+        # become a configurable setting when #74 is fixed.
+        self._send_channel, self._recv_channel = trio.open_memory_channel(
+            message_queue_size_do_not_use)
         self._pings = OrderedDict()
         # Set when the server has received a connection request event. This
         # future is never set on client connections.


### PR DESCRIPTION
As described in the issue, get_message() was raising connection closed
even if there were pending messages. Per Nathaniel's suggestion, the
proper behavior is this:

1. If the remote endpoint closed the connection, then the local endpoint
   may continue reading all messages sent prior to closing.
2. If the local endpoint closed the connection, then the local endpoint
   may not read any more messages.

I added tests for these two conditions and implemented the behavior by
closing the ReceiveChannel inside the connection's `aclose()`. This
requires a bit of additional exception handling inside `get_message()`
and inside the reader task.

One slight surprise is that the test couldn't be written due to the bug
in #74! The client would hang because the reader task is blocked by
the unconsumed messages. So I changed the channel size to 32, which
allows this test to work, and I will replace this hard-coded value
when I fix #74.