### PR TITLE
Add support for rejecting connection (#107)

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -20,10 +20,10 @@ Requests
 
     .. autoattribute:: headers
     .. autoattribute:: proposed_subprotocols
-    .. autoattribute:: subprotocol
     .. autoattribute:: local
     .. autoattribute:: remote
     .. automethod:: accept
+    .. automethod:: reject
 
 Connections
 -----------
@@ -47,8 +47,13 @@ Connections
     .. autoattribute:: is_server
     .. autoattribute:: local
     .. autoattribute:: remote
+
+    This object exposes the following properties related to the WebSocket
+    handshake.
+
     .. autoattribute:: path
     .. autoattribute:: subprotocol
+    .. autoattribute:: handshake_headers
 
     A connection object has a pair of methods for sending and receiving
     WebSocket messages. Messages can be ``str`` or ``bytes`` objects.
@@ -80,6 +85,8 @@ Connections
     :members:
 
 .. autoexception:: ConnectionClosed
+
+.. autoexception:: ConnectionRejected
 
 Utilities
 ---------

--- a/trio_websocket/__init__.py
+++ b/trio_websocket/__init__.py
@@ -1,6 +1,7 @@
 from ._impl import (
     CloseReason,
     ConnectionClosed,
+    ConnectionRejected,
     connect_websocket,
     connect_websocket_url,
     open_websocket,

--- a/trio_websocket/_impl.py
+++ b/trio_websocket/_impl.py
@@ -839,7 +839,7 @@ class WebSocketConnection(trio.abc.AsyncResource):
 
     async def _accept(self, request, subprotocol, extra_headers):
         '''
-        Accept a given proposal.
+        Accept the handshake.
 
         This method is only applicable to server-side connections.
 
@@ -872,7 +872,7 @@ class WebSocketConnection(trio.abc.AsyncResource):
             has_body=bool(body))
         await self._send(reject_conn)
         if body:
-            reject_body = RejectData(data=body, body_finished=True)
+            reject_body = RejectData(data=body)
             await self._send(reject_body)
         self._close_reason = CloseReason(1006, 'Rejected WebSocket handshake')
         self._close_handshake.set()


### PR DESCRIPTION
Adds a `reject()` method to the request class. Since this new method has an `extra_headers` argument, I also added `extra_headers` to `accept()` for symmetry. (Not exactly what was requested in #110 but definitely related.)