### PR TITLE
Fix some deprecations in tests + remove some dependencies

### DIFF
--- a/autobahn/client.py
+++ b/autobahn/client.py
@@ -7,7 +7,6 @@ import logging
 
 import trio
 from trio_websocket import open_websocket_url, ConnectionClosed
-from yarl import URL
 
 
 AGENT = 'trio-websocket'
@@ -16,7 +15,7 @@ logger = logging.getLogger('client')
 
 
 async def get_case_count(url):
-    url = URL(url).with_path('/getCaseCount')
+    url = url + '/getCaseCount'
     async with open_websocket_url(url) as conn:
         case_count = await conn.get_message()
         logger.info('Case count=%s', case_count)
@@ -24,7 +23,7 @@ async def get_case_count(url):
 
 
 async def run_case(url, case):
-    url = URL(url).with_path('/runCase').with_query(case=case, agent=AGENT)
+    url = url + '/runCase?case={}&agent={}'.format(case, AGENT)
     try:
         async with open_websocket_url(url) as conn:
             while True:
@@ -35,7 +34,7 @@ async def run_case(url, case):
 
 
 async def update_reports(url):
-    url = URL(url).with_path('/updateReports').with_query(agent=AGENT)
+    url = url + '/updateReports?agent={}'.format(AGENT)
     async with open_websocket_url(url) as conn:
         # This command runs as soon as we connect to it, so we don't need to
         # send any messages.

--- a/autobahn/server.py
+++ b/autobahn/server.py
@@ -13,7 +13,7 @@ import logging
 import sys
 
 import trio
-from trio_websocket import WebSocketServer, ConnectionClosed
+from trio_websocket import serve_websocket, ConnectionClosed
 
 
 BIND_IP = '0.0.0.0'
@@ -27,19 +27,19 @@ connection_count = 0
 async def main():
     ''' Main entry point. '''
     logger.info('Starting websocket server on ws://%s:%d', BIND_IP, BIND_PORT)
-    server = WebSocketServer(handler, BIND_IP, BIND_PORT, ssl_context=None)
-    await server.listen()
+    await serve_websocket(handler, BIND_IP, BIND_PORT, ssl_context=None)
 
 
-async def handler(websocket):
+async def handler(request):
     ''' Reverse incoming websocket messages and send them back. '''
     global connection_count
     connection_count += 1
     logger.info('Connection #%d', connection_count)
+    ws = await request.accept()
     while True:
         try:
-            message = await websocket.get_message()
-            await websocket.send_message(message)
+            message = await ws.get_message()
+            await ws.send_message(message)
         except ConnectionClosed:
             break
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -177,5 +177,4 @@ epub_exclude_files = ['search.html']
 # -- Extension configuration -------------------------------------------------
 intersphinx_mapping = {
     'trio': ('https://trio.readthedocs.io/en/stable/', None),
-    'yarl': ('https://yarl.readthedocs.io/en/stable/', None),
 }

--- a/examples/client.py
+++ b/examples/client.py
@@ -10,10 +10,10 @@ import logging
 import pathlib
 import ssl
 import sys
+import urllib.parse
 
 import trio
 from trio_websocket import open_websocket_url, ConnectionClosed, HandshakeError
-import yarl
 
 
 logging.basicConfig(level=logging.DEBUG)
@@ -40,7 +40,7 @@ def parse_args():
 
 async def main(args):
     ''' Main entry point, returning False in the case of logged error. '''
-    if yarl.URL(args.url).scheme == 'wss':
+    if urllib.parse.urlsplit(args.url).scheme == 'wss':
         # Configure SSL context to handle our self-signed certificate. Most
         # clients won't need to do this.
         try:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+attrs>=19.2.0
 coveralls
 pytest>=4.6
 pytest-cov

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,5 +6,6 @@ pytest-trio>=0.5.0
 sphinx
 sphinxcontrib-trio
 sphinx_rtd_theme
+trio>=0.15.0
 trustme
 twine

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         # TODO: confirm whether wsaccel is relevant to performance
         # Disabled on pypy: https://github.com/methane/wsaccel/issues/19
         'wsaccel>=0.6.2,<0.7;implementation_name!="pypy"',
-        'wsproto>=0.14,<0.15',
+        'wsproto>=0.14,<0.16',
         'yarl>=1.2.6,<2'
     ],
     project_urls={

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup(
         'async_generator>=1.10,<2',
         'trio>=0.11',
         'wsproto>=0.14,<0.16',
-        'yarl>=1.2.6,<2'
     ],
     project_urls={
         'Bug Reports': 'https://github.com/HyperionGray/trio-websocket/issues',

--- a/setup.py
+++ b/setup.py
@@ -41,9 +41,6 @@ setup(
     install_requires=[
         'async_generator>=1.10,<2',
         'trio>=0.11',
-        # TODO: confirm whether wsaccel is relevant to performance
-        # Disabled on pypy: https://github.com/methane/wsaccel/issues/19
-        'wsaccel>=0.6.2,<0.7;implementation_name!="pypy"',
         'wsproto>=0.14,<0.16',
         'yarl>=1.2.6,<2'
     ],

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
     packages=find_packages(exclude=['docs', 'examples', 'tests']),
     install_requires=[
         'async_generator>=1.10,<2',
-        'ipaddress>=1.0.22,<2',
         'trio>=0.11',
         # TODO: confirm whether wsaccel is relevant to performance
         # Disabled on pypy: https://github.com/methane/wsaccel/issues/19

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -135,7 +135,7 @@ class MemoryListener(trio.abc.Listener):
         return client
 
     async def accept(self):
-        await trio.hazmat.checkpoint()
+        await trio.lowlevel.checkpoint()
         assert not self.closed
         if self.accept_hook is not None:
             await self.accept_hook()
@@ -145,7 +145,7 @@ class MemoryListener(trio.abc.Listener):
 
     async def aclose(self):
         self.closed = True
-        await trio.hazmat.checkpoint()
+        await trio.lowlevel.checkpoint()
 
 
 async def test_endpoint_ipv4():
@@ -181,7 +181,7 @@ async def test_server_has_listeners(nursery):
 
 
 async def test_serve(nursery):
-    task = trio.hazmat.current_task()
+    task = trio.lowlevel.current_task()
     server = await nursery.start(serve_websocket, echo_request_handler, HOST, 0,
         None)
     port = server.port
@@ -215,7 +215,7 @@ async def test_serve_ssl(nursery):
 
 
 async def test_serve_handler_nursery(nursery):
-    task = trio.hazmat.current_task()
+    task = trio.lowlevel.current_task()
     async with trio.open_nursery() as handler_nursery:
         serve_with_nursery = partial(serve_websocket, echo_request_handler,
             HOST, 0, None, handler_nursery=handler_nursery)
@@ -231,7 +231,7 @@ async def test_serve_handler_nursery(nursery):
 
 
 async def test_serve_with_zero_listeners(nursery):
-    task = trio.hazmat.current_task()
+    task = trio.lowlevel.current_task()
     with pytest.raises(ValueError):
         server = WebSocketServer(echo_request_handler, [])
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -121,7 +121,7 @@ class fail_after:
         return wrapper
 
 
-@attr.s(hash=False, cmp=False)
+@attr.s(hash=False, eq=False)
 class MemoryListener(trio.abc.Listener):
     closed = attr.ib(default=False)
     accepted_streams = attr.ib(factory=list)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -287,6 +287,13 @@ async def test_client_open_invalid_url(echo_server):
             pass
 
 
+async def test_ascii_encoded_path_is_ok(echo_server):
+    path = '%D7%90%D7%91%D7%90?%D7%90%D7%9E%D7%90'
+    url = 'ws://{}:{}{}/{}'.format(HOST, echo_server.port, RESOURCE, path)
+    async with open_websocket_url(url) as conn:
+        assert conn.path == RESOURCE + '/' + path
+
+
 @patch('trio_websocket._impl.open_websocket')
 def test_client_open_url_options(open_websocket_mock):
     """open_websocket_url() must pass its options on to open_websocket()"""

--- a/trio_websocket/_impl.py
+++ b/trio_websocket/_impl.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 from functools import partial
+from ipaddress import ip_address
 import itertools
 import logging
 import random
@@ -7,7 +8,6 @@ import ssl
 import struct
 
 from async_generator import async_generator, yield_, asynccontextmanager
-from ipaddress import ip_address
 import trio
 import trio.abc
 from wsproto import ConnectionType, WSConnection


### PR DESCRIPTION
The first two commits fix some deprecations; since they are only in the tests I didn't bother with backward compatibility with older trio/attrs versions.

The next commits remove the ipaddress, wsaccel and yarl dependencies, please see the commit messages for details.

Once Python 3.5 is dropped can also remove the async_generator dep I think, which will leave only trio and wsproto.