### PR TITLE
Fix " Illegal target characters" when connecting to URL with zero-length path

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -276,6 +276,10 @@ async def test_client_open(echo_server):
 
 
 async def test_client_open_url(echo_server):
+    url = 'ws://{}:{}/'.format(HOST, echo_server.port)
+    async with open_websocket_url(url) as conn:
+        assert conn.path == '/'
+
     url = 'ws://{}:{}{}/path'.format(HOST, echo_server.port, RESOURCE)
     async with open_websocket_url(url) as conn:
         assert conn.path == RESOURCE + '/path'
@@ -283,6 +287,11 @@ async def test_client_open_url(echo_server):
     url = 'ws://{}:{}{}?foo=bar'.format(HOST, echo_server.port, RESOURCE)
     async with open_websocket_url(url) as conn:
         assert conn.path == RESOURCE + '?foo=bar'
+
+    # Zero-length path becomes '/'.
+    url = 'ws://{}:{}'.format(HOST, echo_server.port)
+    async with open_websocket_url(url) as conn:
+        assert conn.path == '/'
 
 
 async def test_client_open_invalid_url(echo_server):

--- a/trio_websocket/_impl.py
+++ b/trio_websocket/_impl.py
@@ -291,6 +291,11 @@ def _url_to_host(url, ssl_context):
     else:
         port = 443 if ssl_context else 80
     path_qs = parts.path
+    # RFC 7230, Section 5.3.1:
+    # If the target URI's path component is empty, the client MUST
+    # send "/" as the path within the origin-form of request-target.
+    if not path_qs:
+        path_qs = '/'
     if '?' in url:
         path_qs += '?' + parts.query
     return host, port, path_qs, ssl_context


### PR DESCRIPTION
Fixes #148.

This regressed in 0233e2176731a190a515c025c0762c19f (version 0.9.0) due
to different behavior between yarl and urllib.parse.urlsplit on a URL
without a path component like "wss://ws.kraken.com". yarl makes this `/`
while urlsplit makes it ''. h11 expects `/` as specified in the quoted
RFC.