### PR TITLE
fix reason not being set after local close

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -955,6 +955,35 @@ async def test_remote_close_local_message_race(nursery, autojump_clock):
         await client.send_message('bar')
 
 
+async def test_message_after_local_close_race(nursery):
+    """test message send during local-initiated close handshake (issue #158)"""
+
+    async def handler(request: WebSocketRequest):
+        await request.accept()
+        await trio.sleep_forever()
+
+    server = await nursery.start(
+        partial(serve_websocket, handler, HOST, 0, ssl_context=None))
+
+    client = await connect_websocket(nursery, HOST, server.port,
+                                     RESOURCE, use_ssl=False)
+    orig_send = client._send
+    close_sent = trio.Event()
+
+    async def _send_wrapper(event):
+        if isinstance(event, CloseConnection):
+            close_sent.set()
+        return await orig_send(event)
+
+    client._send = _send_wrapper
+    assert not client.closed
+    nursery.start_soon(client.aclose)
+    await close_sent.wait()
+    assert client.closed
+    with pytest.raises(ConnectionClosed):
+        await client.send_message('hello')
+
+
 @fail_after(DEFAULT_TEST_MAX_DURATION)
 async def test_server_tcp_closed_on_close_connection_event(nursery):
     """ensure server closes TCP immediately after receiving CloseConnection"""

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -791,7 +791,7 @@ async def test_server_handler_exit(nursery, autojump_clock):
     server = await nursery.start(
         partial(serve_websocket, handler, HOST, 0, ssl_context=None))
 
-    # connection should close when server handler exists
+    # connection should close when server handler exits
     with trio.fail_after(2):
         async with open_websocket(
                 HOST, server.port, '/', use_ssl=False) as connection:


### PR DESCRIPTION
During a local-initiated close handshake, the following incorrect behavior was observed:
  * `closed` attribute would be `None`
  * `get_message()` would be silently ignored (wsproto < 0.2.0) or leak a `LocalProtocolException` (wsproto >= 0.2.0)

Upon local-initiated close, `closed` will now have the reason, and `get_message()` will raise `ConnectionClosed`.

Fixes #158.