### PR TITLE
include LICENSE in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
Thank you for `trio-websocket`!

This PR ensures the `LICENSE` file is included in `sdist` distributions, which, while not _required_ by the terms of the MIT license, is helpful for downstreams.

In my case, I'm looking to package this for conda-forge, which generally requires _some_ license documentation for all packages. We're not blocked, as such, as we can source it from github from the same tag, but keeping everything in one tarball makes things a bit more reliable.

Thanks again!