### PR TITLE
Set minimum Python version to 3.7 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ same port is straightforward.  There has yet to be a performance comparison.
 
 ## Installation
 
-This library requires Python 3.6 or greater. To install from PyPI:
+This library requires Python 3.7 or greater. To install from PyPI:
 
     pip install trio-websocket
 


### PR DESCRIPTION
## Set minimum Python version to 3.7 in README.md

The latest version of ``trio-websocket`` just bumped the minimum version of Python to ``3.7``, but the README.md still shows an outdated version.