### PR TITLE
trio_websocket/_impl.py: Don't reply to pings on a locally closed connection

### DIFF
--- a/trio_websocket/_impl.py
+++ b/trio_websocket/_impl.py
@@ -1495,7 +1495,8 @@ class WebSocketConnection(trio.abc.AsyncResource):
         :param wsproto.events.Ping event:
         '''
         logger.debug('%s ping %r', self, event.payload)
-        await self._send(event.response())
+        if self._wsproto.state != ConnectionState.LOCAL_CLOSING:
+            await self._send(event.response())
 
     async def _handle_pong_event(self, event: wsproto.events.Pong) -> None:
         '''


### PR DESCRIPTION
I encountered [this issue](https://github.com/python-trio/trio-websocket/issues/184) in my application and applied the following fix in my local fork.  I am making the PR in case there is interest in applying this fix on the main repo.

For clarity, the source of the problem seems to be the fact that when calling `aclose()` we will send a `CloseConnection` message [here](https://github.com/python-trio/trio-websocket/blob/master/trio_websocket/_impl.py#L1171) and then allow context switch on await before we disable processing of incoming messages [here](https://github.com/python-trio/trio-websocket/blob/master/trio_websocket/_impl.py#L1347) but after wsproto will change its connection state to `LOCAL_CLOSING`. During that time gap we can receive Ping message which will result in exception upon handling it.

Fixes #184 