### PR TITLE
GitHub Actions: Add Python 3.14 and PyPy 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - name: Setup Python
+      - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - name: Setup Python
+      - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
           cache-dependency-path: 'requirements-dev.txt'
-      - run: pip install cryptography  # TODO(cclauss): Fix requirements for PyPy v3.11
-        if: matrix.python-version == 'pypy-3.11'
       - run: pip install . -r requirements-dev.txt
       - run: make test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
           cache-dependency-path: 'requirements-dev.txt'
+      - run: pip install cryptography  # TODO(cclauss): Fix requirements for PyPy v3.11
+        if: matrix.python-version == 'pypy-3.11'
       - run: pip install . -r requirements-dev.txt
       - run: make test
 
@@ -73,7 +75,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.15']
+        python-version: ['3.14']
     steps:
       - uses: actions/checkout@v5
       - name: Setup Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Setup Python
-        uses: actions/setup-python@v3
+      - uses: actions/checkout@v5
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
           cache: 'pip'
           cache-dependency-path: 'requirements-dev-full.txt'
       - run: pip install . -r requirements-dev-full.txt
@@ -35,9 +36,9 @@ jobs:
         python-version: ['3.8']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -53,12 +54,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['pypy-3.9','pypy-3.10']
+        python-version: ['pypy-3.10','pypy-3.11']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -72,12 +73,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.14-dev']
+        python-version: ['3.15']
     steps:
-      - uses: actions/checkout@v3
-      - name: Setup Python
-        uses: actions/setup-python@v3
+      - uses: actions/checkout@v5
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - run: pip install . -r requirements-dev.in
       - run: make test

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,7 +17,7 @@ click==8.1.8
     # via pip-tools
 coverage[toml]==7.6.1
     # via pytest-cov
-cryptography==44.0.1
+cryptography==46.0.1
     # via trustme
 exceptiongroup==1.2.2 ; python_version < "3.11"
     # via


### PR DESCRIPTION
* https://www.python.org/downloads/release/python-3140/
* https://github.com/actions/python-versions/releases
* https://pypy.org/download.html -- PyPy only keeps a single release as current.

`requirements-dev.txt`:
```diff
- cryptography==44.0.1
+ cryptography==46.0.1
```
* For compatibility with PyPy3.11 https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst

Note: Python 3.8 went EOL one year ago.  Python 3.9 will EOL in 10 days, when Python 3.14 will be released.